### PR TITLE
Routing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,56 +12,44 @@ The package was built to provide a simple message queue for embedded application
 go get github.com/stevecallear/emmq@latest
 ```
 ```
-ex, err := emmq.Open("messages")
+e, err := emmq.Open("messages")
 if err != nil {
     log.Fatal(err)
 }
-defer ex.Close()
+defer e.Close()
 
-ch, err := ex.Consume(context.Background(), "topic")
+q, err := e.Declare("queue")
 if err != nil {
     log.Fatal(err)
 }
 
-if err = ex.Publish("topic", []byte("value")); err != nil {
+q.Bind("topic")
+
+c, err := e.Consume(context.Background(), "topic")
+if err != nil {
     log.Fatal(err)
 }
 
-d := <- ch
+if err = e.Publish("topic", []byte("value")); err != nil {
+    log.Fatal(err)
+}
+
+d := <- c
 log.Print(string(d.Value))
 
-if err = d.Ack(); err != nil {
+if err = d.Delete(); err != nil {
     log.Fatal(err)
 }
 ```
 
 ## Message delivery
-All published messages are persisted prior to sending to consuming channels. If no channel has been configured to consume a specific topic prefix, then the message will be persisted in ready state. If a channel has been configured and the message is not delayed then it will be persisted in an unacked state and immediately sent to the consuming channel.
+Messages are published for a specific topic. Each topic can be bound to multiple queues and a single queue can be bound to multiple topics. If no queues are bound to a specific topic, then published messages will be discarded.
 
-Publish options can be specified per-message using `WithDelay` or can be forced to wait for the next poll interval using `WithWait`.
+All published messages are persisted prior to sending to consuming channels. If bound queues have not been configured to consume messages, then they will be persisted for immediate consumption. If bound queues have been configured to consume messages then they will be persisted with the configured visibility timeout and immediately sent to the consuming channel.
 
-Poll interval and batch size can be configured when opening the exchange using `WithPolling`.
+Messages can be delayed by using `WithDelay` or can be forced to wait for the next poll interval using `WithWait`.
 
-Published messages can be consumed using a topic prefix by calling `Consume`. If a delivery is successfully processed, then `Ack` should be called to remove it. If a failure occurs then `Nack` should be called.
+Delivered messages that have been processed should be deleted by calling `Delete`. If the message is not deleted then it will be delivered again once the visibility timeout has expired.
 
-### Topic prefixes
-Due to the underlying use of key prefixes to allow topics with BadgerDB, consume channels use a topic prefix. This means that if a channel consumes `package.` then it will receive messages for any topic with that prefix, for example `package.message`. In some scenarios this will result in unexpected behaviour. To avoid bugs, an error will be returned on calls to consume if the specified topic prefix would mask an existing channel.
-
-Attempting to consume the same topic prefix more than once will also return an error. The rationale for this is that supporting competing consumers at a topic level without more complex routing would undermine the durability guarantees.
-
-### Consume ordering
-Messages are generally sent to consumer channels in FIFO order to nanosecond precision. If multiple messages are published within the same nanosecond then consume order will be random for those messages only. It is also possible for immediate published messages to be consumed prior to delayed messages in some scenarios, although this can be prevented by using `WithWait`.
-
-## Failed messages
-Messages are considered failed if they are either not acked, or are explicitly nacked, falling into 'unacked' and 'nacked' statuses respectively.
-
-Failed messages are persisted indefinitely unless explicitly redriven or purged. Redriven messages will be made ready for consumption ahead of all other messages at the first poll interval. Purged messages are deleted.
-```
-if err := ex.Purge(emmq.StatusNacked); err != nil {
-    log.Fatal(err)
-}
-
-if err := ex.Redrive(emmq.StatusUnacked); err != nil {
-    log.Fatal(err)
-}
-```
+### Delivery order
+Messages are generally sent to consumer channels in FIFO order to nanosecond precision. If multiple messages are published within the same nanosecond then consume order will be random for those messages only.

--- a/delivery.go
+++ b/delivery.go
@@ -1,0 +1,14 @@
+package emmq
+
+// Delivery represents a message delivery
+type Delivery struct {
+	Key      Key
+	Value    []byte
+	exchange *Exchange
+}
+
+// Delete deletes the message
+// If a message is not deleted then it will be re-delivered after the visibility timeout
+func (d *Delivery) Delete() error {
+	return d.exchange.delete(d.Key)
+}

--- a/delivery_test.go
+++ b/delivery_test.go
@@ -1,0 +1,44 @@
+package emmq_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/stevecallear/emmq"
+)
+
+func TestDelivery_Delete(t *testing.T) {
+	t.Run("should delete the message", func(t *testing.T) {
+		e, close := newExchange(func(o *emmq.Options) {
+			o.PollInterval = 50 * time.Millisecond
+			o.VisibilityTimeout = 100 * time.Millisecond
+		})
+		defer close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		qn, tn := uuid.NewString(), uuid.NewString()
+
+		q, err := e.Declare(qn)
+		assertErrorExists(t, err, false)
+
+		q.Bind(tn)
+
+		c, err := q.Consume(ctx)
+		assertErrorExists(t, err, false)
+
+		err = e.Publish(tn, []byte{})
+		assertErrorExists(t, err, false)
+
+		assertDeliveries(t, c, 1, func(d emmq.Delivery) {
+			err := d.Delete()
+			assertErrorExists(t, err, false)
+		})
+
+		assertNoDeliveries(t, c, 200*time.Millisecond)
+	})
+}

--- a/emmq_test.go
+++ b/emmq_test.go
@@ -1,0 +1,115 @@
+package emmq_test
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/stevecallear/emmq"
+)
+
+var (
+	sut          *emmq.Exchange
+	pollInterval = 100 * time.Millisecond
+)
+
+func TestMain(m *testing.M) {
+	e, close := newExchange(emmq.WithPolling(pollInterval, 10))
+	defer close()
+	sut = e
+	m.Run()
+}
+
+func newExchange(optFns ...func(*emmq.Options)) (*emmq.Exchange, func()) {
+	p := "test-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	e, err := emmq.Open(p, optFns...)
+	if err != nil {
+		panic(err)
+	}
+
+	return e, func() {
+		defer os.RemoveAll(p)
+		if err := e.Close(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func merge(cs ...<-chan emmq.Delivery) <-chan emmq.Delivery {
+	mc := make(chan emmq.Delivery)
+	for _, c := range cs {
+		go func(c <-chan emmq.Delivery) {
+			for d := range c {
+				mc <- d
+			}
+		}(c)
+	}
+
+	return mc
+}
+
+func assertErrorExists(t *testing.T, act error, exp bool) {
+	if act != nil && !exp {
+		t.Fatalf("got %v, expected nil", act)
+	}
+
+	if act == nil && exp {
+		t.Fatal("got nil, expected an error")
+	}
+}
+
+func assertBytesEqual(t *testing.T, act, exp []byte) {
+	if !bytes.Equal(act, exp) {
+		t.Errorf("got %v, expected %v", act, exp)
+	}
+}
+
+func assertDeliveries(t *testing.T, c <-chan emmq.Delivery, n int, fns ...func(emmq.Delivery)) {
+	q := make(chan struct{})
+
+	go func() {
+		defer close(q)
+
+		var dc int
+		for {
+			d := <-c
+			dc++
+
+			for _, fn := range fns {
+				fn(d)
+			}
+
+			if dc >= n {
+				return
+			}
+		}
+	}()
+
+	tt := time.NewTimer(5 * time.Second)
+	for {
+		select {
+		case <-q:
+			return
+		case <-tt.C:
+			t.Error("expected a delivery, got none")
+			return
+		}
+	}
+}
+
+func assertNoDeliveries(t *testing.T, c <-chan emmq.Delivery, wait time.Duration) {
+	dt := time.NewTimer(wait)
+	for {
+		select {
+		case <-c:
+			t.Error("got delivery, expected none")
+			return
+		case <-dt.C:
+			return
+		}
+	}
+}

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,1 +1,1 @@
-messages/
+emmq/

--- a/exchange.go
+++ b/exchange.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 	"time"
 
@@ -14,20 +13,22 @@ import (
 type (
 	// Exchange represents a message exchange
 	Exchange struct {
-		opts  Options
-		db    *badger.DB
-		chans map[string]chan Delivery
-		quit  chan struct{}
-		wg    *sync.WaitGroup
-		mu    *sync.RWMutex
+		opts   Options
+		db     *badger.DB
+		queues map[string]chan Delivery
+		topics map[string]map[string]struct{}
+		quit   chan struct{}
+		wg     *sync.WaitGroup
+		mu     *sync.RWMutex
 	}
 
-	// Options represents message exchange options
+	// Options represents exchange options
 	Options struct {
-		PollInterval  time.Duration
-		PollBatchSize int
-		BadgerOptions badger.Options
-		OnError       func(error)
+		PollInterval      time.Duration
+		PollBatchSize     int
+		VisibilityTimeout time.Duration
+		BadgerOptions     badger.Options
+		OnError           func(error)
 	}
 
 	// PublishOptions represents message publish options
@@ -35,356 +36,7 @@ type (
 		Wait  bool
 		Delay time.Duration
 	}
-
-	// RedriveOptions represents message redrive options
-	RedriveOptions struct {
-		TopicPrefix string
-		BatchSize   int
-		Offset      time.Duration
-	}
-
-	// Delivery represents a message delivery
-	Delivery struct {
-		Key      Key
-		Value    []byte
-		exchange *Exchange
-	}
 )
-
-// Open opens a new message exchange with the specified options
-func Open(path string, optFns ...func(*Options)) (*Exchange, error) {
-	o := Options{
-		PollInterval:  100 * time.Millisecond,
-		PollBatchSize: 10,
-		BadgerOptions: badger.DefaultOptions(path),
-		OnError: func(err error) {
-			log.Println(err)
-		},
-	}
-
-	for _, fn := range optFns {
-		fn(&o)
-	}
-
-	db, err := badger.Open(o.BadgerOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Exchange{
-		opts:  o,
-		db:    db,
-		chans: map[string]chan Delivery{},
-		quit:  make(chan struct{}),
-		wg:    new(sync.WaitGroup),
-		mu:    new(sync.RWMutex),
-	}, nil
-}
-
-// Publish publishes the specified message
-func (e *Exchange) Publish(topic string, value []byte, optFns ...func(*PublishOptions)) error {
-	var o PublishOptions
-	for _, fn := range optFns {
-		fn(&o)
-	}
-
-	if o.Delay > 0 || o.Wait {
-		return e.publishDelayed(topic, value, o.Delay)
-	}
-
-	return e.publishImmediate(topic, value)
-}
-
-func (e *Exchange) publishImmediate(topic string, value []byte) error {
-	n := time.Now().UTC()
-
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	ch, ok := e.chans[topic]
-	if !ok {
-		k := NewKey(topic, StatusReady, n)
-		return e.db.Update(func(tx *badger.Txn) error {
-			return tx.Set(k, value)
-		})
-	}
-
-	k := NewKey(topic, StatusUnacked, n)
-	err := e.db.Update(func(tx *badger.Txn) error {
-		return tx.Set(k, value)
-	})
-	if err != nil {
-		return err
-	}
-
-	go func() {
-		ch <- Delivery{
-			Key:      k,
-			Value:    value,
-			exchange: e,
-		}
-	}()
-
-	return nil
-}
-
-func (e *Exchange) publishDelayed(topic string, value []byte, delay time.Duration) error {
-	k := NewKey(topic, StatusReady, time.Now().UTC().Add(delay))
-	return e.db.Update(func(tx *badger.Txn) error {
-		return tx.Set(k, value)
-	})
-}
-
-// Consume returns a delivery channel for the specified topic prefix
-func (e *Exchange) Consume(ctx context.Context, topicPrefix string) (<-chan Delivery, error) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	if _, exists := e.chans[topicPrefix]; exists {
-		return nil, fmt.Errorf("topic %s already consumed", topicPrefix)
-	}
-
-	// ensure that the topic would not mask another channel
-	for k := range e.chans {
-		if strings.HasPrefix(k, topicPrefix) {
-			return nil, fmt.Errorf("topic %s would mask %s", topicPrefix, k)
-		}
-		if strings.HasPrefix(topicPrefix, k) {
-			return nil, fmt.Errorf("topic %s would be masked by %s", topicPrefix, k)
-		}
-	}
-
-	ch := make(chan Delivery)
-	e.chans[topicPrefix] = ch
-
-	e.wg.Add(1)
-	go func() {
-		defer e.wg.Done()
-
-		defer func() {
-			e.mu.Lock()
-			defer e.mu.Unlock()
-			delete(e.chans, topicPrefix)
-		}()
-
-		t := time.NewTicker(e.opts.PollInterval)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-e.quit:
-				return
-			case <-t.C:
-				ds, err := e.pop(topicPrefix, e.opts.PollBatchSize)
-				if err != nil {
-					e.opts.OnError(err)
-					continue
-				}
-
-				for _, d := range ds {
-					ch <- d
-				}
-			}
-		}
-	}()
-
-	return ch, nil
-}
-
-func (e *Exchange) pop(topic string, count int) ([]Delivery, error) {
-	var res []Delivery
-	pre := encodePrefix(topic, StatusReady)
-
-	err := e.db.Update(func(tx *badger.Txn) error {
-		it := tx.NewIterator(badger.DefaultIteratorOptions)
-		defer it.Close()
-
-		var c int
-		for it.Seek(pre); it.ValidForPrefix(pre); it.Next() {
-			if !it.Valid() {
-				break
-			}
-
-			i := it.Item()
-			k := Key(i.KeyCopy(nil))
-
-			if k.DueAt().After(time.Now().UTC()) {
-				break
-			}
-
-			v, err := i.ValueCopy(nil)
-			if err != nil {
-				return err
-			}
-
-			uk := k.withStatus(StatusUnacked)
-			if err := tx.Set(uk, v); err != nil {
-				return err
-			}
-
-			if err := tx.Delete(k); err != nil {
-				return err
-			}
-
-			res = append(res, Delivery{
-				Key:      uk,
-				Value:    v,
-				exchange: e,
-			})
-
-			c++
-			if c >= count {
-				break
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return res, nil
-}
-
-// Redrive redrives all messages of the specified status(es)
-func (e *Exchange) Redrive(s Status, optFns ...func(*RedriveOptions)) error {
-	o := RedriveOptions{BatchSize: e.opts.PollBatchSize}
-	for _, fn := range optFns {
-		fn(&o)
-	}
-
-	for _, cs := range []Status{StatusUnacked, StatusNacked} {
-		if hasStatus(s, cs) {
-			if err := e.redriveStatus(cs, o); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func (e *Exchange) redriveStatus(s Status, o RedriveOptions) error {
-	pre := encodePrefix(o.TopicPrefix, s)
-	now := time.Now().UTC()
-
-	for {
-		var more bool
-		err := e.db.Update(func(tx *badger.Txn) error {
-			it := tx.NewIterator(badger.DefaultIteratorOptions)
-			defer it.Close()
-
-			var c int
-			for it.Seek(pre); it.ValidForPrefix(pre); it.Next() {
-				if !it.Valid() {
-					break
-				}
-
-				ii := it.Item()
-				k := Key(ii.KeyCopy(nil))
-
-				if o.Offset > 0 && k.DueAt().Add(o.Offset).After(now) {
-					break
-				}
-
-				v, err := ii.ValueCopy(nil)
-				if err != nil {
-					return err
-				}
-
-				nk := k.withStatus(StatusReady)
-				if err := tx.Set(nk, v); err != nil {
-					return err
-				}
-
-				if err := tx.Delete(k); err != nil {
-					return err
-				}
-
-				c++
-				if c >= o.BatchSize {
-					more = true
-					break
-				}
-			}
-
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-
-		if !more {
-			break
-		}
-	}
-
-	return nil
-}
-
-// Purge purges all messages of the specified status(es)
-func (e *Exchange) Purge(s Status) error {
-	ps := [][]byte{}
-	for _, cs := range []Status{StatusReady, StatusUnacked, StatusNacked} {
-		if hasStatus(s, cs) {
-			ps = append(ps, []byte{byte(cs)})
-		}
-	}
-
-	if len(ps) < 1 {
-		return nil
-	}
-
-	return e.db.DropPrefix(ps...)
-}
-
-// Close closes the exchange and the underlying database
-func (e *Exchange) Close() error {
-	close(e.quit)
-	e.wg.Wait()
-
-	return e.db.Close()
-}
-
-func (e *Exchange) ack(k Key) error {
-	return e.db.Update(func(tx *badger.Txn) error {
-		return tx.Delete(k)
-	})
-}
-
-func (e *Exchange) nack(k Key) error {
-	nk := k.withStatus(StatusNacked)
-	return e.db.Update(func(tx *badger.Txn) error {
-		i, err := tx.Get(k)
-		if err != nil {
-			return err
-		}
-
-		v, err := i.ValueCopy(nil)
-		if err != nil {
-			return err
-		}
-
-		if err = tx.Set(nk, v); err != nil {
-			return err
-		}
-
-		return tx.Delete(k)
-	})
-}
-
-// Ack acknowledges the delivery
-// Acked messages cannot be redriven or purged
-func (d *Delivery) Ack() error {
-	return d.exchange.ack(d.Key)
-}
-
-// Nack marks the delivery as nacked
-// Nacked messages can be redriven or purged
-func (d *Delivery) Nack() error {
-	return d.exchange.nack(d.Key)
-}
 
 // WithDelay delays message consumption until the first poll interval
 // after the specified duration
@@ -407,4 +59,248 @@ func WithWait() func(*PublishOptions) {
 	return func(o *PublishOptions) {
 		o.Wait = true
 	}
+}
+
+// Open opens a new exchange with the specified options
+func Open(path string, optFns ...func(*Options)) (*Exchange, error) {
+	o := Options{
+		PollInterval:      100 * time.Millisecond,
+		PollBatchSize:     10,
+		VisibilityTimeout: 30 * time.Second,
+		BadgerOptions:     badger.DefaultOptions(path),
+		OnError: func(err error) {
+			log.Println(err)
+		},
+	}
+	for _, fn := range optFns {
+		fn(&o)
+	}
+
+	db, err := badger.Open(o.BadgerOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Exchange{
+		opts:   o,
+		db:     db,
+		queues: map[string]chan Delivery{},
+		topics: map[string]map[string]struct{}{},
+		quit:   make(chan struct{}),
+		wg:     new(sync.WaitGroup),
+		mu:     new(sync.RWMutex),
+	}, nil
+}
+
+// Declare declares a new queue with the specified name
+func (e *Exchange) Declare(queue string) (Queue, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if _, exists := e.queues[queue]; exists {
+		return Queue{}, fmt.Errorf("queue already exists: %s", queue)
+	}
+
+	p, err := encodePrefix(queue)
+	if err != nil {
+		return Queue{}, err
+	}
+
+	e.queues[queue] = nil
+	return Queue{
+		name:     queue,
+		prefix:   p,
+		exchange: e,
+	}, nil
+}
+
+// Publish publishes the specified message
+// If no queues are bound to the topic then the message will be discarded
+func (e *Exchange) Publish(topic string, value []byte, optFns ...func(*PublishOptions)) error {
+	var o PublishOptions
+	for _, fn := range optFns {
+		fn(&o)
+	}
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	wait := o.Wait || o.Delay > 0
+	now := time.Now().UTC()
+
+	wb := e.db.NewWriteBatch()
+	defer wb.Cancel()
+
+	dm := map[chan Delivery]Delivery{}
+
+	for q := range e.topics[topic] {
+		var due time.Time
+
+		ch := e.queues[q]
+		if wait || ch == nil {
+			due = now.Add(o.Delay)
+		} else {
+			due = now.Add(e.opts.VisibilityTimeout)
+		}
+
+		k, err := NewKey(q, due)
+		if err != nil {
+			return err
+		}
+
+		if err = wb.Set(k, value); err != nil {
+			return err
+		}
+
+		if ch != nil {
+			dm[ch] = Delivery{
+				Key:      k,
+				Value:    value,
+				exchange: e,
+			}
+		}
+	}
+
+	if err := wb.Flush(); err != nil {
+		return err
+	}
+
+	if !wait {
+		go func() {
+			for ch, d := range dm {
+				ch <- d
+			}
+		}()
+	}
+
+	return nil
+}
+
+// PurgeAll purges all messages in all queues
+func (e *Exchange) PurgeAll() error {
+	return e.db.DropAll()
+}
+
+// Close closes the exchange and the underlying database
+func (e *Exchange) Close() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	close(e.quit)
+	e.wg.Wait()
+
+	return e.db.Close()
+}
+
+func (e *Exchange) bind(topic string, q Queue) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if t, ok := e.topics[topic]; ok {
+		t[q.name] = struct{}{}
+	} else {
+		e.topics[topic] = map[string]struct{}{
+			q.name: {},
+		}
+	}
+}
+
+func (e *Exchange) consume(ctx context.Context, q Queue) (<-chan Delivery, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if ch, exists := e.queues[q.name]; exists && ch != nil {
+		return nil, fmt.Errorf("queue already consumed: %s", q.name)
+	}
+
+	ch := make(chan Delivery)
+	e.queues[q.name] = ch
+
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+
+		t := time.NewTicker(e.opts.PollInterval)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-e.quit:
+				return
+			case <-t.C:
+				ds, err := e.popBatch(q.prefix)
+				if err != nil {
+					e.opts.OnError(err)
+					continue
+				}
+
+				for _, d := range ds {
+					ch <- d
+				}
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func (e *Exchange) popBatch(prefix []byte) ([]Delivery, error) {
+	var ds []Delivery
+
+	err := e.db.Update(func(tx *badger.Txn) error {
+		it := tx.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+
+		var c int
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if !it.Valid() {
+				break
+			}
+
+			i := it.Item()
+			k := Key(i.KeyCopy(nil))
+
+			if k.DueAt().After(time.Now().UTC()) {
+				break
+			}
+
+			v, err := i.ValueCopy(nil)
+			if err != nil {
+				return err
+			}
+
+			dk := k.Delay(e.opts.VisibilityTimeout)
+			if err := tx.Set(dk, v); err != nil {
+				return err
+			}
+
+			if err := tx.Delete(k); err != nil {
+				return err
+			}
+
+			ds = append(ds, Delivery{Key: dk, Value: v, exchange: e})
+
+			c++
+			if c >= e.opts.PollBatchSize {
+				break
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ds, nil
+}
+
+func (e *Exchange) delete(k Key) error {
+	return e.db.Update(func(tx *badger.Txn) error {
+		return tx.Delete(k)
+	})
+}
+
+func (e *Exchange) purge(prefix []byte) error {
+	return e.db.DropPrefix(prefix)
 }

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,28 @@
+package emmq
+
+import "context"
+
+// Queue represents a message queue
+type Queue struct {
+	name     string
+	prefix   []byte
+	exchange *Exchange
+}
+
+// Bind binds the queue to the specified topics
+// A topic may be bound to multiple queues
+func (q Queue) Bind(topics ...string) {
+	for _, t := range topics {
+		q.exchange.bind(t, q)
+	}
+}
+
+// Consume consumes queue messages
+func (q Queue) Consume(ctx context.Context) (<-chan Delivery, error) {
+	return q.exchange.consume(ctx, q)
+}
+
+// Purge purges all queue messages
+func (q Queue) Purge() error {
+	return q.exchange.purge(q.prefix)
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,0 +1,128 @@
+package emmq_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/stevecallear/emmq"
+)
+
+func TestQueue_Consume(t *testing.T) {
+	t.Run("should return an error if the queue is already consumed", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		q, err := sut.Declare(uuid.NewString())
+		assertErrorExists(t, err, false)
+
+		_, err = q.Consume(ctx)
+		assertErrorExists(t, err, false)
+
+		_, err = q.Consume(ctx)
+		if err == nil {
+			t.Error("got nil, expected an error")
+		}
+	})
+
+	t.Run("should apply the poll batch size", func(t *testing.T) {
+		e, close := newExchange(emmq.WithPolling(100*time.Millisecond, 2))
+		defer close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		q, err := e.Declare(uuid.NewString())
+		assertErrorExists(t, err, false)
+
+		tn := uuid.NewString()
+		q.Bind(tn)
+
+		c, err := q.Consume(ctx)
+		assertErrorExists(t, err, false)
+
+		for _, v := range []string{"a", "b", "c"} {
+			err = e.Publish(tn, []byte(v), emmq.WithWait())
+			assertErrorExists(t, err, false)
+		}
+
+		assertDeliveries(t, c, 2)
+		assertNoDeliveries(t, c, 90*time.Millisecond)
+	})
+}
+
+func TestQueue_Bind(t *testing.T) {
+	t.Run("should bind to multiple topics", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		qn, t1, t2 := uuid.NewString(), uuid.NewString(), uuid.NewString()
+
+		q, err := sut.Declare(qn)
+		assertErrorExists(t, err, false)
+
+		q.Bind(t1, t2)
+
+		c, err := q.Consume(ctx)
+		assertErrorExists(t, err, false)
+
+		for _, tn := range []string{t1, t2} {
+			err = sut.Publish(tn, []byte("value"))
+			assertErrorExists(t, err, false)
+		}
+
+		assertDeliveries(t, c, 2)
+	})
+
+	t.Run("should bind to multiple queues", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		tn, qn1, qn2 := uuid.NewString(), uuid.NewString(), uuid.NewString()
+
+		cs := []<-chan emmq.Delivery{}
+		for _, qn := range []string{qn1, qn2} {
+			q, err := sut.Declare(qn)
+			assertErrorExists(t, err, false)
+
+			q.Bind(tn)
+
+			c, err := q.Consume(ctx)
+			assertErrorExists(t, err, false)
+
+			cs = append(cs, c)
+		}
+
+		err := sut.Publish(tn, []byte("value"))
+		assertErrorExists(t, err, false)
+
+		c := merge(cs...)
+		assertDeliveries(t, c, 2)
+	})
+}
+
+func TestQueue_Purge(t *testing.T) {
+	t.Run("should purge queue messages", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		q, err := sut.Declare(uuid.NewString())
+		assertErrorExists(t, err, false)
+
+		tn := uuid.NewString()
+		q.Bind(tn)
+
+		c, err := q.Consume(ctx)
+		assertErrorExists(t, err, false)
+
+		err = sut.Publish(tn, []byte{}, emmq.WithWait())
+		assertErrorExists(t, err, false)
+
+		err = q.Purge()
+		assertErrorExists(t, err, false)
+
+		assertNoDeliveries(t, c, 2*pollInterval)
+	})
+}


### PR DESCRIPTION
This PR fundamentally rewrites `emmq` to support more complex routing between topics and queues. While the package was originally designed for simplicity, the absence of fan out/in routing between topics and queues made implementing a number of basic patterns unnecessarily complicated.

In addition, the status-based approach of ensuring persistence was arguably too complex. This PR replaces that with a visibility timeout approach, similar to that within AWS SNS/SQS, which greatly simplifies usage. More complex failure scenario handling can be implemented on top of this pattern.

Almost every aspect of the API has been changed and may continue to evolve as I experiment further.